### PR TITLE
nfs-shares: add support for autoscaling groups

### DIFF
--- a/docs/asset-managers/nfs-shares.md
+++ b/docs/asset-managers/nfs-shares.md
@@ -1,9 +1,22 @@
 # Asset manager: `nfs-shares`
 
-The asset manager `nfs-shares` provides an asset type of the same name for resizing NFS shares
+The asset manager `nfs-shares` provides asset types for resizing NFS shares
 managed by [OpenStack Manila](https://wiki.openstack.org/wiki/Manila).
 
+* The asset type `nfs-shares` matches all Manila shares in the respective project.
+* Asset types of the form `nfs-shares-group:$NAME`, where `$NAME =~ /[A-Za-z0-9-]+/`,
+  match only those Manila shares that have the given name value in the metadata
+  key `autoscaling_group`.
+
 ## User considerations
+
+### Inter-resource constraints
+
+In each project, there can only be **either** an `nfs-shares` resource **or**
+any number of `nfs-shares-group:$NAME` resources. This ensures that each share
+only belongs to once resource at most. Having a share match both the
+`nfs-shares` resource and an `nfs-shares-group:$NAME` resource is not allowed
+because it could result in contradictory autoscaling behavior.
 
 ### Resource configuration
 

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -582,6 +582,14 @@ func TestPutResourceValidationErrors(baseT *testing.T) {
 			"type-specific configuration must be provided for this asset type",
 		)
 
+		expectErrors("qux",
+			assert.JSONObject{
+				"critical_threshold": assert.JSONObject{"usage_percent": 90},
+				"size_steps":         assert.JSONObject{"percent": 10},
+			},
+			"cannot create qux resource because there is a foo resource",
+		)
+
 		//none of this should have touched the DB
 		t.ExpectResources(h.DB, allResources...)
 	})

--- a/internal/api/shared_test.go
+++ b/internal/api/shared_test.go
@@ -41,6 +41,7 @@ func withHandler(t test.T, cfg core.Config, timeNow func() time.Time, action fun
 		team := core.AssetManagerTeam{
 			&plugins.AssetManagerStatic{AssetType: "foo"},
 			&plugins.AssetManagerStatic{AssetType: "bar", UsageMetrics: []db.UsageMetric{"first", "second"}, ExpectsConfiguration: true},
+			&plugins.AssetManagerStatic{AssetType: "qux", ConflictsWithAssetType: "foo"},
 		}
 		mv := &MockValidator{}
 

--- a/internal/core/assets.go
+++ b/internal/core/assets.go
@@ -79,13 +79,16 @@ type AssetManager interface {
 	//A non-nil return value makes the API deny any attempts to create a resource
 	//with that scope and asset type with that error.
 	//
-	//The initial intended purpose is to allow resources for some scopes, but
-	//deny them for others. The second purpose is to validate plugin-specific
-	//configuration passed in the `configJSON` parameter.
+	//This can perform multiple types of validations:
+	//- allowing resources for some scopes, but not others (e.g. only projects
+	//  with a specific marker)
+	//- validating plugin-specific configuration in `configJSON`
+	//- allowing resources depending on which other resources exist in the same
+	//scope, by checking `isExistingResource`
 	//
 	//Simple implementations should return nil for empty `configJSON` and
 	//`core.ErrNoConfigurationAllowed` otherwise.
-	CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string) error
+	CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string, existingResources []db.AssetType) error
 
 	ListAssets(res db.Resource) ([]string, error)
 	//The returned Outcome should be either Succeeded, Failed or Errored, but not Cancelled.

--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -78,7 +78,7 @@ func (m *assetManagerNFS) InfoForAssetType(assetType db.AssetType) *core.AssetTy
 }
 
 //CheckResourceAllowed implements the core.AssetManager interface.
-func (m *assetManagerNFS) CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string) error {
+func (m *assetManagerNFS) CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string, existingResources []db.AssetType) error {
 	if configJSON != "" {
 		return core.ErrNoConfigurationAllowed
 	}

--- a/internal/plugins/project-quota.go
+++ b/internal/plugins/project-quota.go
@@ -115,7 +115,7 @@ func (m *assetManagerProjectQuota) InfoForAssetType(assetType db.AssetType) *cor
 var errNotAllowedForThisProject = errors.New("autoscaling is not permitted for this resource because of cluster-level policies")
 
 //CheckResourceAllowed implements the core.AssetManager interface.
-func (m *assetManagerProjectQuota) CheckResourceAllowed(assetType db.AssetType, projectID string, configJSON string) error {
+func (m *assetManagerProjectQuota) CheckResourceAllowed(assetType db.AssetType, projectID string, configJSON string, existingResources []db.AssetType) error {
 	if configJSON != "" {
 		return core.ErrNoConfigurationAllowed
 	}

--- a/internal/plugins/server-groups.go
+++ b/internal/plugins/server-groups.go
@@ -115,7 +115,7 @@ func (m *assetManagerServerGroups) InfoForAssetType(assetType db.AssetType) *cor
 }
 
 //CheckResourceAllowed implements the core.AssetManager interface.
-func (m *assetManagerServerGroups) CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string) error {
+func (m *assetManagerServerGroups) CheckResourceAllowed(assetType db.AssetType, scopeUUID string, configJSON string, existingResources []db.AssetType) error {
 	//check that the server group exists and is in the right project
 	groupID := strings.TrimPrefix(string(assetType), "server-group:")
 	group, err := m.getServerGroup(groupID)

--- a/main.go
+++ b/main.go
@@ -439,7 +439,7 @@ PROMPT:
 			res.AssetType = assetType
 			res.ScopeUUID = fields[1]
 			res.ConfigJSON = configJSON
-			err := manager.CheckResourceAllowed(res.AssetType, res.ScopeUUID, res.ConfigJSON)
+			err := manager.CheckResourceAllowed(res.AssetType, res.ScopeUUID, res.ConfigJSON, nil)
 			if err != nil {
 				logg.Error("CheckResourceAllowed failed: " + err.Error())
 				continue


### PR DESCRIPTION
I realize that I should hold myself to the same standard that I'm asking of you, and allow you to review my code. Since this change is not super-urgent yet, I'm using the opportunity.

A customer requested the ability to have multiple different autoscaling configurations on shares within the same project. So with this, they can have resources like `nfs-shares-group:first`, `nfs-shares-group:second`, etc. within one project. A few adjustments in the base machinery were necessary to enforce that each specific project can have **either** `nfs-shares` **or** `nfs-shares-group:...`, but not both at the same time to avoid multiple resources with different configurations governing the same shares.
