### PR TITLE
server-groups: report "quota exceeded" as failed instead of errored

### DIFF
--- a/internal/plugins/server-groups.go
+++ b/internal/plugins/server-groups.go
@@ -418,7 +418,12 @@ func (m *assetManagerServerGroups) createServers(res db.Resource, cfg configForS
 
 		server, err := servers.Create(computeV2, opts(name)).Extract()
 		if err != nil {
-			return castellum.OperationOutcomeErrored, fmt.Errorf("cannot create server %s in %s: %w", name, res.AssetType, err)
+			err = fmt.Errorf("cannot create server %s in %s: %w", name, res.AssetType, err)
+			if strings.Contains(err.Error(), "Quota exceeded for ") {
+				return castellum.OperationOutcomeFailed, err
+			} else {
+				return castellum.OperationOutcomeErrored, err
+			}
 		}
 		serversInCreation[server.ID] = server.Status
 	}


### PR DESCRIPTION
The difference is that outcome "errored" is reported to the cloud admins (i.e. us), whereas outcome "failed" is reported to the project admins. Failing an upscale of a server group due to missing project quota is something that the customer needs to address.