### PR TITLE
Optimize worst db query

### DIFF
--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -107,4 +107,10 @@ var SQLMigrations = map[string]string{
 			usage                  TEXT        NOT NULL
 		);
 	`,
+	"022_add_index_to_assets_next_scrape_at.up.sql": `
+		CREATE INDEX ON assets (next_scrape_at);
+	`,
+	"022_add_index_to_assets_next_scrape_at.down.sql": `
+		DROP INDEX assets_next_scrape_at_idx;
+	`,
 }


### PR DESCRIPTION
```
Before:
> EXPLAIN ANALYZE SELECT * FROM assets WHERE next_scrape_at <= NOW()  ORDER BY next_scrape_at ASC, id ASC  FOR UPDATE SKIP LOCKED LIMIT 3;
+-------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                              |
|-------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=860.37..860.41 rows=3 width=137) (actual time=2.933..2.939 rows=3 loops=1)                                 |
|   ->  LockRows  (cost=860.37..876.21 rows=1267 width=137) (actual time=2.932..2.937 rows=3 loops=1)                     |
|         ->  Sort  (cost=860.37..863.54 rows=1267 width=137) (actual time=2.909..2.910 rows=3 loops=1)                   |
|               Sort Key: next_scrape_at, id                                                                              |
|               Sort Method: quicksort  Memory: 26kB                                                                      |
|               ->  Seq Scan on assets  (cost=0.00..844.00 rows=1267 width=137) (actual time=0.168..2.888 rows=7 loops=1) |
|                     Filter: (next_scrape_at <= now())                                                                   |
|                     Rows Removed by Filter: 9526                                                                        |
| Planning Time: 6.214 ms                                                                                                 |
| Execution Time: 2.976 ms                                                                                                |
+-------------------------------------------------------------------------------------------------------------------------+

After:
> EXPLAIN ANALYZE SELECT * FROM assets WHERE next_scrape_at <= NOW()  ORDER BY next_scrape_at ASC, id ASC  FOR UPDATE SKIP LOCKED LIMIT 3;
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                 |
|------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Limit  (cost=0.74..2.21 rows=3 width=137) (actual time=0.977..0.982 rows=3 loops=1)                                                                        |
|   ->  LockRows  (cost=0.74..912.04 rows=1849 width=137) (actual time=0.976..0.980 rows=3 loops=1)                                                          |
|         ->  Incremental Sort  (cost=0.74..893.55 rows=1849 width=137) (actual time=0.096..0.098 rows=13 loops=1)                                           |
|               Sort Key: next_scrape_at, id                                                                                                                 |
|               Presorted Key: next_scrape_at                                                                                                                |
|               Full-sort Groups: 1  Sort Method: quicksort  Average Memory: 30kB  Peak Memory: 30kB                                                         |
|               ->  Index Scan using assets_next_scrape_at_idx on assets  (cost=0.29..810.34 rows=1849 width=137) (actual time=0.019..0.061 rows=33 loops=1) |
|                     Index Cond: (next_scrape_at <= now())                                                                                                  |
| Planning Time: 2.214 ms                                                                                                                                    |
| Execution Time: 1.040 ms                                                                                                                                   |
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
```