### PR TITLE
chore: addendum to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,22 @@ converted into a FinishedOperation, even if that operation moved into state "fai
 the "greenlit" state at all. Resize operations that move into state "failed" or "errored" are counted by
 `castellum_operation_state_transitions{to_state=~"failed|errored"}`.
 
+## Support, Feedback, Contributing
+
+This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-an-issue). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](https://github.com/sapcc/castellum/blob/master/CONTRIBUTING.md).
+
+## Security / Disclosure
+
+If you find any bug that may be a security problem, please follow our instructions [in our security policy](https://github.com/SAP-cloud-infrastructure/.github/blob/main/SECURITY.md) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
+
+## Code of Conduct
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP-cloud-infrastructure/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
+
+## Licensing
+
+Copyright 2019-2025 SAP SE or an SAP affiliate company and castellum contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/sapcc/castellum).
+
 [pq-uri]: https://www.postgresql.org/docs/9.6/static/libpq-connect.html#LIBPQ-CONNSTRING
 [os-env]: https://docs.openstack.org/python-openstackclient/latest/cli/man/openstack.html
 [os-pol]: https://docs.openstack.org/oslo.policy/latest/admin/policy-json-file.html


### PR DESCRIPTION
This change adds metadata for compliance with the [REUSE framework](https://reuse.software/) and adds SAP-standard README information about contributions, security and copyright. I'm aware of the autogenerated REUSE.toml and tried to work around the autogenerated lines, but let's see in our meeting this week what we need to do to make it work smoothly.