### PR TITLE
fix asset type parsing

### DIFF
--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -37,9 +37,9 @@ func (m *assetManagerNFS) parseAssetType(assetType db.AssetType) Option[assetTyp
 		return Some(assetTypeNFS{AllShares: true})
 	}
 
-	if nfsType, ok := strings.CutPrefix(string(assetType), "nfs-shares-group:"); ok {
-		if shareTypeID, ok := m.shareTypeNameToID[nfsType]; ok {
-			return Some(assetTypeNFS{AllShares: false, ShareTypeName: nfsType, ShareTypeID: shareTypeID})
+	if nfsGroup, ok := strings.CutPrefix(string(assetType), "nfs-shares-group:"); ok {
+		if shareGroupID, ok := m.shareTypeNameToID[nfsGroup]; ok {
+			return Some(assetTypeNFS{AllShares: false, ShareTypeName: nfsGroup, shareGroupID: shareTypeID})
 		}
 	}
 	return None[assetTypeNFS]()

--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -37,7 +37,7 @@ func (m *assetManagerNFS) parseAssetType(assetType db.AssetType) Option[assetTyp
 		return Some(assetTypeNFS{AllShares: true})
 	}
 
-	if nfsType, ok := strings.CutPrefix(string(assetType), "nfs-shares-type:"); ok {
+	if nfsType, ok := strings.CutPrefix(string(assetType), "nfs-shares-group:"); ok {
 		if shareTypeID, ok := m.shareTypeNameToID[nfsType]; ok {
 			return Some(assetTypeNFS{AllShares: false, ShareTypeName: nfsType, ShareTypeID: shareTypeID})
 		}

--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -29,7 +29,7 @@ import (
 type assetTypeNFS struct {
 	AllShares     bool
 	ShareTypeName string
-	ShareTypeID   string
+	shareGroupID  string
 }
 
 func (m *assetManagerNFS) parseAssetType(assetType db.AssetType) Option[assetTypeNFS] {
@@ -39,7 +39,7 @@ func (m *assetManagerNFS) parseAssetType(assetType db.AssetType) Option[assetTyp
 
 	if nfsGroup, ok := strings.CutPrefix(string(assetType), "nfs-shares-group:"); ok {
 		if shareGroupID, ok := m.shareTypeNameToID[nfsGroup]; ok {
-			return Some(assetTypeNFS{AllShares: false, ShareTypeName: nfsGroup, shareGroupID: shareTypeID})
+			return Some(assetTypeNFS{AllShares: false, ShareTypeName: nfsGroup, shareGroupID: shareGroupID})
 		}
 	}
 	return None[assetTypeNFS]()
@@ -148,7 +148,7 @@ func (m *assetManagerNFS) ListAssets(ctx context.Context, res db.Resource) ([]st
 	} else {
 		promQuery = fmt.Sprintf(
 			`count by (id) (openstack_manila_shares_size_gauge{project_id="%s",status!="error",share_type_id="%s"})`,
-			res.ScopeUUID, assetType.ShareTypeID,
+			res.ScopeUUID, assetType.shareGroupID,
 		)
 	}
 	vector, err := m.Discovery.GetVector(ctx, promQuery)


### PR DESCRIPTION
The current setting contradicts the values of the policy yaml, which causes `forbidden` errors.
See: https://github.com/sapcc/helm-charts/blob/f14419f767f9a6f651f2dfe4dfc3ad607fc07a33/openstack/castellum/files/policy.yaml#L13