### PR TITLE
consider private share types for autoscaling configs

### DIFF
--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -46,7 +46,7 @@ func (m *assetManagerNFS) parseAssetType(assetType db.AssetType) Option[assetTyp
 }
 
 func (m *assetManagerNFS) getShareTypeInfo(ctx context.Context) error {
-	pages, err := sharetypes.List(m.Manila, nil).AllPages(ctx)
+	pages, err := sharetypes.List(m.Manila, sharetypes.ListOpts{IsPublic: "All"}).AllPages(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The manila API fetches both, public and private shareTypes by using the `is_public` option `All`.
I tested the result by using the builtin testing tool.