### PR TITLE
nfs-shares: consider empty exclusion-reasons metric family as error

### DIFF
--- a/docs/asset-managers/nfs-shares.md
+++ b/docs/asset-managers/nfs-shares.md
@@ -42,6 +42,10 @@ Manila API queries.
 If you want Castellum to ignore a Manila share, fill the `manila_share_exclusion_reasons_for_castellum` metric as
 described above.
 
+If any of the aforementioned metric families do not contain any entries, Castellum will assume that this is because of a problem with metric scraping.
+Castellum will then rather throw errors instead of silently proceeding on the assumption that there are no shares.
+For the exclusion-reasons metric family specifically, it may be necessary to add dummy metrics when there are legitimately no excluded shares.
+
 ### Configuration
 
 | Variable | Default | Explanation |

--- a/internal/plugins/nfs-shares.go
+++ b/internal/plugins/nfs-shares.go
@@ -349,7 +349,6 @@ var (
 			Filler: func(entry *manilaShareMetrics, sample *model.Sample) {
 				entry.ExclusionReason = string(sample.Metric["reason"])
 			},
-			ZeroResultsIsNotAnError: true, // the specific setups that warrant exclusion may not exist everywhere
 		},
 		{
 			Query:       manilaSizeBytesQuery,


### PR DESCRIPTION
Part of the fix for INC15375812.

**Warning:** Only merge and deploy this once https://github.com/sapcc/helm-charts/pull/9685 has been deployed to all prod regions.